### PR TITLE
Debug correct groups from datastore

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -232,7 +232,7 @@ module.exports = class AccessUtils {
       },
     })
       .then(groups => {
-        debug('getUserGroups returning from datastore: %o', currentUserGroups)
+        debug('getUserGroups returning from datastore: %o', groups)
         cb(null, groups)
       })
       .catch(cb)


### PR DESCRIPTION
In `utils.js` the following chunk of code gets the groups from the datastore, however, the debugger logs the groups from cache.

```js
// Otherwise lookup from the datastore.
    this.app.models[this.options.groupAccessModel].find({
      where: {
        userId,
      },
    })
      .then(groups => {
        debug('getUserGroups returning from datastore: %o', groups /* this used to log currentUserGroups */)
        cb(null, groups)
      })
      .catch(cb)
```